### PR TITLE
Member not application extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,11 +109,11 @@ Options:
   --issuer-key-file FILENAME   Issuer key file
   --issuer-cert-file FILENAME  Issuer certificate file
   --member-uri TEXT            Member uri
+  --application-uri TEXT       Application uri
   --organization-name TEXT     Organization name
   --country TEXT               Country
   --state TEXT                 State
   -r, --role TEXT              Client roles
-  --application-uri TEXT       Application uri
   --help                       Show this message and exit.
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ib1-directory"
-version = "0.6"
+version = "0.7"
 description = "A library to simplify working with the IB1 Trust Framework directory"
 authors = ["Kip Parker <kip.parker@icebreakerone.org>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ib1-directory"
-version = "0.7"
+version = "0.8"
 description = "A library to simplify working with the IB1 Trust Framework directory"
 authors = ["Kip Parker <kip.parker@icebreakerone.org>"]
 readme = "README.md"

--- a/src/ib1/directory/certificates.py
+++ b/src/ib1/directory/certificates.py
@@ -9,7 +9,7 @@ from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric.types import PrivateKeyTypes
 
-from ib1.directory.extensions import encode_roles, encode_application
+from ib1.directory.extensions import encode_roles, encode_member
 
 
 def _ca_extensions_cert(
@@ -278,7 +278,7 @@ def sign_csr(
     if roles:
         cert_builder = encode_roles(cert_builder, roles)
     if application:
-        cert_builder = encode_application(cert_builder, application)
+        cert_builder = encode_member(cert_builder, application)
 
     cert = cert_builder.sign(issuer_key, hashes.SHA256(), default_backend())
     return cert

--- a/src/ib1/directory/certificates.py
+++ b/src/ib1/directory/certificates.py
@@ -22,7 +22,7 @@ def _ca_extensions_cert(
     valid_to: datetime = datetime.datetime.now(datetime.timezone.utc)
     + datetime.timedelta(days=365),
 ) -> x509.Certificate:
-    return (
+    builder = (
         x509.CertificateBuilder()
         .subject_name(subject)
         .issuer_name(issuer_name)
@@ -57,8 +57,9 @@ def _ca_extensions_cert(
             ),
             critical=True,
         )
-        .sign(signing_key, hashes.SHA256(), default_backend())
     )
+
+    return builder.sign(signing_key, hashes.SHA256(), default_backend())
 
 
 def load_certificate(cert_pem: bytes) -> x509.Certificate:
@@ -205,7 +206,7 @@ def sign_csr(
     csr_pem: bytes,
     subject: x509.Name,
     roles: List[str] | None = None,
-    application: str | None = None,
+    member: str | None = None,
     server: bool = False,
     days_valid: int = 365,
 ) -> x509.Certificate:
@@ -218,8 +219,8 @@ def sign_csr(
         csr_pem (bytes): CSR in PEM format.
         days_valid (int): Number of days the certificate is valid for.
         subject (x509.Name): Subject name for the certificate.
-        roles (List[str], optional): Roles to encode in the certificate.
-        application (str, optional): Application to encode in the certificate.
+        roles (List[str], optional): Roles to encode in the certificate as a custom extension
+        member (str, optional): Member to encode in the certificate as a custom extension
         server (bool, optional): Whether the certificate is for a server.
 
     Returns:
@@ -233,8 +234,11 @@ def sign_csr(
         .subject_name(subject)
         .issuer_name(issuer_cert.subject)
         .public_key(csr.public_key())
-        .not_valid_before(datetime.utcnow())
-        .not_valid_after(datetime.utcnow() + datetime.timedelta(days=days_valid))
+        .not_valid_before(datetime.datetime.now(datetime.timezone.utc))
+        .not_valid_after(
+            datetime.datetime.now(datetime.timezone.utc)
+            + datetime.timedelta(days=days_valid)
+        )
         .serial_number(x509.random_serial_number())
     )
     # Add SKI (Subject Key Identifier)
@@ -269,7 +273,6 @@ def sign_csr(
         )
     else:
         common_name = str(subject.get_attributes_for_oid(NameOID.COMMON_NAME)[0].value)
-        print(common_name)
         cert_builder = cert_builder.add_extension(
             x509.SubjectAlternativeName([x509.UniformResourceIdentifier(common_name)]),
             critical=False,
@@ -277,8 +280,8 @@ def sign_csr(
 
     if roles:
         cert_builder = encode_roles(cert_builder, roles)
-    if application:
-        cert_builder = encode_member(cert_builder, application)
+    if member:
+        cert_builder = encode_member(cert_builder, member)
 
     cert = cert_builder.sign(issuer_key, hashes.SHA256(), default_backend())
     return cert

--- a/src/ib1/directory/cli.py
+++ b/src/ib1/directory/cli.py
@@ -108,6 +108,12 @@ def create_ca(usage: str, country: str, state: str, framework: str):
     default="https://directory.estf.ib1.org/member/2876152",
 )
 @click.option(
+    "--application-uri",
+    type=str,
+    help="Application uri",
+    default="https://directory.estf.ib1.org/scheme/electricty/application/26241",
+)
+@click.option(
     "--organization-name",
     type=str,
     help="Organization name",
@@ -124,21 +130,15 @@ def create_ca(usage: str, country: str, state: str, framework: str):
         "https://registry.estf.ib1.org/scheme/electricty/role/supply-voltage-reader"
     ],
 )
-@click.option(
-    "--application-uri",
-    type=str,
-    help="Application uri",
-    default="https://directory.estf.ib1.org/scheme/electricty/application/26241",
-)
 def create_client_certificates(
     issuer_key_file: click.Path,
     issuer_cert_file: click.Path,
     member_uri: str,
+    application_uri: str,
     organization_name: str,
     country: str,
     state: str,
     role: list[str],
-    application_uri: str,
 ):
     """
     Create a private key and use it generate a CSR, then sign the CSR with a CA key and certificate.
@@ -157,7 +157,7 @@ def create_client_certificates(
         country=country,
         state=state,
         organization_name=organization_name,
-        common_name=member_uri,
+        common_name=application_uri,
     )
     csr = (
         x509.CertificateSigningRequestBuilder()
@@ -172,7 +172,7 @@ def create_client_certificates(
         csr_pem=csr_pem,
         subject=subject,
         roles=role,
-        application=application_uri,
+        member=member_uri,
     )
     client_certificate_pem = client_certificate.public_bytes(serialization.Encoding.PEM)
     bundle = get_bundle(client_certificate_pem, issuer_cert_pem)
@@ -194,7 +194,6 @@ def create_client_certificates(
         f.write(bundle)
 
 
-# Write a command create server certificates with similar functionality except we must accept a domain name rather than application name, and we don't need to encode rules or applicaiton_uri
 @cli.command()
 @click.option(
     "--issuer-key-file",

--- a/src/ib1/directory/extensions.py
+++ b/src/ib1/directory/extensions.py
@@ -5,6 +5,7 @@ from ib1.directory import der
 
 ROLE_IDENTIFIER = "1.3.6.1.4.1.62329.1.1"
 APPLICATION_IDENTIFIER = "1.3.6.1.4.1.62329.1.2"
+MEMBER_IDENTIFIER = "1.3.6.1.4.1.62329.1.3"
 
 
 def _add_extension(
@@ -64,7 +65,7 @@ def encode_roles(cert_builder: x509.CertificateBuilder, roles: list[str]):
     return _add_extension(cert_builder, ROLE_IDENTIFIER, der.encode_sequence(roles))
 
 
-def encode_application(cert_builder: x509.CertificateBuilder, application: str):
+def encode_member(cert_builder: x509.CertificateBuilder, member: str):
     """
     Encode application information into the certificate builder as an extension.
 
@@ -75,9 +76,7 @@ def encode_application(cert_builder: x509.CertificateBuilder, application: str):
     Returns:
         x509.CertificateBuilder: The updated certificate builder with the application extension.
     """
-    return _add_extension(
-        cert_builder, APPLICATION_IDENTIFIER, der.encode_string(application)
-    )
+    return _add_extension(cert_builder, MEMBER_IDENTIFIER, der.encode_string(member))
 
 
 def decode_roles(cert: x509.Certificate) -> list[str]:
@@ -102,9 +101,9 @@ def decode_roles(cert: x509.Certificate) -> list[str]:
     return der.decode_sequence(role_der)
 
 
-def decode_application(cert: x509.Certificate) -> str:
+def decode_member(cert: x509.Certificate) -> str:
     """
-    Decode application information from a certificate.
+    Decode member information from a certificate.
 
     Args:
         cert (x509.Certificate): The certificate.
@@ -116,7 +115,7 @@ def decode_application(cert: x509.Certificate) -> str:
         CertificateExtensionError: If the certificate does not include application information.
     """
     try:
-        application_der = _extension_value(cert, APPLICATION_IDENTIFIER)
+        application_der = _extension_value(cert, MEMBER_IDENTIFIER)
     except x509.ExtensionNotFound:
         raise CertificateExtensionError(
             "Client certificate does not include application information"

--- a/src/ib1/directory/extensions.py
+++ b/src/ib1/directory/extensions.py
@@ -4,7 +4,6 @@ from ib1.directory.exceptions import CertificateRoleError, CertificateExtensionE
 from ib1.directory import der
 
 ROLE_IDENTIFIER = "1.3.6.1.4.1.62329.1.1"
-APPLICATION_IDENTIFIER = "1.3.6.1.4.1.62329.1.2"
 MEMBER_IDENTIFIER = "1.3.6.1.4.1.62329.1.3"
 
 
@@ -67,14 +66,14 @@ def encode_roles(cert_builder: x509.CertificateBuilder, roles: list[str]):
 
 def encode_member(cert_builder: x509.CertificateBuilder, member: str):
     """
-    Encode application information into the certificate builder as an extension.
+    Encode member information into the certificate builder as an extension.
 
     Args:
         cert_builder (x509.CertificateBuilder): The certificate builder.
-        application (str): The application information to encode.
+        member (str): The member information to encode.
 
     Returns:
-        x509.CertificateBuilder: The updated certificate builder with the application extension.
+        x509.CertificateBuilder: The updated certificate builder with the member extension.
     """
     return _add_extension(cert_builder, MEMBER_IDENTIFIER, der.encode_string(member))
 
@@ -109,18 +108,18 @@ def decode_member(cert: x509.Certificate) -> str:
         cert (x509.Certificate): The certificate.
 
     Returns:
-        str: The decoded application information.
+        str: The decoded member information.
 
     Raises:
-        CertificateExtensionError: If the certificate does not include application information.
+        CertificateExtensionError: If the certificate does not include member information.
     """
     try:
-        application_der = _extension_value(cert, MEMBER_IDENTIFIER)
+        member_der = _extension_value(cert, MEMBER_IDENTIFIER)
     except x509.ExtensionNotFound:
         raise CertificateExtensionError(
-            "Client certificate does not include application information"
+            "Client certificate does not include member information"
         )
-    return der.decode_string(application_der)
+    return der.decode_string(member_der)
 
 
 def require_role(role_name: str, cert: x509.Certificate) -> bool:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+import datetime
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography import x509
 from cryptography.x509.oid import NameOID
@@ -27,7 +27,9 @@ def certificate_builder():
         .issuer_name(issuer)
         .public_key(private_key.public_key())
         .serial_number(x509.random_serial_number())
-        .not_valid_before(datetime.utcnow())
-        .not_valid_after(datetime.utcnow() + timedelta(days=365))
+        .not_valid_before(datetime.datetime.now(datetime.timezone.utc))
+        .not_valid_after(
+            datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=365)
+        )
     )
     return cert_builder, private_key

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -26,11 +26,11 @@ def test_encode_roles(certificate_builder):  # noqa: F811
 
 def test_encode_member(certificate_builder):  # noqa: F811
     cert_builder, private_key = certificate_builder
-    application = "https://directory.core.trust.ib1.org/member/71212388"
-    cert_builder = encode_member(cert_builder, application)
+    member = "https://directory.core.trust.ib1.org/member/71212388"
+    cert_builder = encode_member(cert_builder, member)
     cert = cert_builder.sign(private_key, hashes.SHA256())
-    decoded_application = decode_member(cert)
-    assert decoded_application == application
+    decoded_member = decode_member(cert)
+    assert decoded_member == member
 
 
 def test_decode_roles_missing_extension(certificate_builder):  # noqa: F811
@@ -40,7 +40,7 @@ def test_decode_roles_missing_extension(certificate_builder):  # noqa: F811
         decode_roles(cert)
 
 
-def test_decode_application_missing_extension(certificate_builder):  # noqa: F811
+def test_decode_member_missing_extension(certificate_builder):  # noqa: F811
     cert_builder, private_key = certificate_builder
     cert = cert_builder.sign(private_key, hashes.SHA256())
     with pytest.raises(CertificateExtensionError):

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -7,9 +7,9 @@ from ib1.directory import (
 )
 from ib1.directory.extensions import (
     encode_roles,
-    encode_application,
+    encode_member,
     decode_roles,
-    decode_application,
+    decode_member,
 )
 
 from tests import certificate_builder  # noqa: F401
@@ -24,12 +24,12 @@ def test_encode_roles(certificate_builder):  # noqa: F811
     assert decoded_roles == roles
 
 
-def test_encode_application(certificate_builder):  # noqa: F811
+def test_encode_member(certificate_builder):  # noqa: F811
     cert_builder, private_key = certificate_builder
-    application = "https://directory.ib1.org/application/123456"
-    cert_builder = encode_application(cert_builder, application)
+    application = "https://directory.core.trust.ib1.org/member/71212388"
+    cert_builder = encode_member(cert_builder, application)
     cert = cert_builder.sign(private_key, hashes.SHA256())
-    decoded_application = decode_application(cert)
+    decoded_application = decode_member(cert)
     assert decoded_application == application
 
 
@@ -44,7 +44,7 @@ def test_decode_application_missing_extension(certificate_builder):  # noqa: F81
     cert_builder, private_key = certificate_builder
     cert = cert_builder.sign(private_key, hashes.SHA256())
     with pytest.raises(CertificateExtensionError):
-        decode_application(cert)
+        decode_member(cert)
 
 
 def test_require_role(certificate_builder):  # noqa: F811


### PR DESCRIPTION
Member is encoded now in the extension. Application uri is only used in subject alternative name.